### PR TITLE
Optimism token

### DIFF
--- a/save-pakistan-contracts/contracts/SavePakistan.sol
+++ b/save-pakistan-contracts/contracts/SavePakistan.sol
@@ -327,7 +327,7 @@ contract SavePakistan is ERC1155, ERC1155Supply, AccessControl, ReentrancyGuard 
      */
     function getLatestOptimismPrice() public view returns (uint256) {
         (, int256 price, , , ) = opPriceFeed.latestRoundData();
-        return uint256(price); // <== 12 digits, 8 decimals, e.g. 132356008734 -> $1323.56008734
+        return uint256(price);
     }
 
     /**

--- a/save-pakistan-contracts/contracts/SavePakistan.sol
+++ b/save-pakistan-contracts/contracts/SavePakistan.sol
@@ -189,6 +189,7 @@ contract SavePakistan is ERC1155, ERC1155Supply, AccessControl, ReentrancyGuard 
     function withdrawTokens() external onlyAdmin {
         usdc.safeTransfer(treasuryAddr, usdc.balanceOf(address(this)));
         usdt.safeTransfer(treasuryAddr, usdt.balanceOf(address(this)));
+        op.safeTransfer(treasuryAddr, op.balanceOf(address(this)));
     }
 
     /**

--- a/save-pakistan-contracts/contracts/mock/MockOpUsdPriceFeed.sol
+++ b/save-pakistan-contracts/contracts/mock/MockOpUsdPriceFeed.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract MockOpUsdPriceFeed {
+    constructor() {}
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (70942, 113589519, 1666831021, 1666831021, 18446744073709626167);
+    }
+}

--- a/save-pakistan-contracts/contracts/mock/OPMock.sol
+++ b/save-pakistan-contracts/contracts/mock/OPMock.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract OPMock is ERC20 {
+    constructor() ERC20("OP Token", "OP") {
+        _mint(address(this), 1_000_000);
+        _mint(msg.sender, 1_000_000);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return 18;
+    }
+
+    function mintTo(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}

--- a/save-pakistan-contracts/contracts/mock/OPMock.sol
+++ b/save-pakistan-contracts/contracts/mock/OPMock.sol
@@ -5,8 +5,8 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract OPMock is ERC20 {
     constructor() ERC20("OP Token", "OP") {
-        _mint(address(this), 1_000_000);
-        _mint(msg.sender, 1_000_000);
+        _mint(address(this), 1_000_000_000_000_000_000_000);
+        _mint(msg.sender, 1_000_000_000_000_000_000_000);
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/save-pakistan-contracts/package.json
+++ b/save-pakistan-contracts/package.json
@@ -2,6 +2,7 @@
   "name": "@save-pakistan/contracts",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "scripts": {
     "postinstall": "hardhat compile",
     "deploy:mainnet": "hardhat run scripts/deploy.mainnet.ts --network optimismEthereum",

--- a/save-pakistan-contracts/test/SavePakistan.spec.ts
+++ b/save-pakistan-contracts/test/SavePakistan.spec.ts
@@ -332,6 +332,28 @@ describe("Spec: SavePakistan", () => {
       expect(currentBalanceBN).to.be.eq(balanceBN.sub(usdcMintRate));
     });
 
+    it.only("should use the Optimism mint rate when token address is the Optimism Token address", async () => {
+      console.log()
+      let tx = await oPMock.mintTo(user1.address, utils.parseUnits("100000000000000000000", 18));
+      await tx.wait();
+
+      const optimismMintRate = await savePakistan.getVariantOptimismMintRate(Variant.TemporaryShelter);
+      const balanceBN = await oPMock.balanceOf(user1.address);
+
+      tx = await oPMock.connect(user1).approve(savePakistan.address, optimismMintRate);
+      await tx.wait();
+
+      tx = await savePakistan
+        .connect(user1)
+        .mintWithToken(Variant.TemporaryShelter, oPMock.address, BigNumber.from("1"));
+      await tx.wait();
+
+      const currentBalanceBN = await oPMock.balanceOf(user1.address);
+      console.log("currentBalanceBN", utils.formatUnits(currentBalanceBN, 18));
+
+      expect(currentBalanceBN).to.be.eq(balanceBN.sub(optimismMintRate));
+    });
+
     it("should mint with quantity 5 and send the correct amount of token", async () => {
       let tx = await usdcMock.mintTo(user1.address, utils.parseUnits("5000", 6));
       await tx.wait();

--- a/save-pakistan-contracts/test/SavePakistan.spec.ts
+++ b/save-pakistan-contracts/test/SavePakistan.spec.ts
@@ -3,7 +3,9 @@ import {
   TreasuryMock,
   USDCMock,
   USDTMock,
+  OPMock,
   MockEthUsdPriceFeed,
+  MockOpUsdPriceFeed
 } from "../typechain-types";
 import { formatEther, formatUnits } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
@@ -28,8 +30,9 @@ describe("Spec: SavePakistan", () => {
   let treasuryMock: TreasuryMock;
   let usdcMock: USDCMock;
   let usdtMock: USDTMock;
-  let wethMock: USDTMock;
+  let oPMock: OPMock;
   let mockEthUsdPriceFeed: MockEthUsdPriceFeed;
+  let mockOpUsdPriceFeed: MockOpUsdPriceFeed;
   let deployer: SignerWithAddress;
   let user1: SignerWithAddress;
   let user2: SignerWithAddress;
@@ -47,23 +50,28 @@ describe("Spec: SavePakistan", () => {
     await treasuryMock.deployed();
 
     // Mock USDC & USDT
-    const [USDCMock, USDTMock, WETHMock, MockEthUsdPriceFeed] = await Promise.all([
+    const [USDCMock, USDTMock, OPMock, MockEthUsdPriceFeed, MockOpUsdPriceFeed] = await Promise.all([
       ethers.getContractFactory("USDCMock"),
       ethers.getContractFactory("USDTMock"),
-      ethers.getContractFactory("USDTMock"),
+      ethers.getContractFactory("OPMock"),
       ethers.getContractFactory("MockEthUsdPriceFeed"),
+      ethers.getContractFactory("MockOpUsdPriceFeed"),
     ]);
-    [usdcMock, usdtMock, wethMock, mockEthUsdPriceFeed] = await Promise.all([
+
+    [usdcMock, usdtMock, oPMock, mockEthUsdPriceFeed, mockOpUsdPriceFeed] = await Promise.all([
       USDCMock.deploy(),
       USDTMock.deploy(),
-      WETHMock.deploy(),
+      OPMock.deploy(),
       MockEthUsdPriceFeed.deploy(),
+      MockOpUsdPriceFeed.deploy()
     ]);
+
     await Promise.all([
       usdcMock.deployed(),
       usdtMock.deployed(),
-      wethMock.deployed(),
+      oPMock.deployed(),
       mockEthUsdPriceFeed.deployed(),
+      mockOpUsdPriceFeed.deployed()
     ]);
 
     // ERC1155
@@ -73,7 +81,9 @@ describe("Spec: SavePakistan", () => {
         treasuryMock.address,
         usdcMock.address,
         usdtMock.address,
+        oPMock.address,
         mockEthUsdPriceFeed.address,
+        mockOpUsdPriceFeed.address,
         baseURI
       )
     );
@@ -124,6 +134,42 @@ describe("Spec: SavePakistan", () => {
     it("should return correct wei price for WaterWheel", async () => {
       const rationBagEtherPrice = await savePakistan.getVariantEtherMintRate(Variant.WaterWheel);
       expect(rationBagEtherPrice).to.be.eq(BigNumber.from("18896447467876039"));
+    });
+  });
+
+  describe("> getVariantOptimismMintRate", () => {
+    it("should return correct wei price for RationBag", async () => {
+      const rationBagEtherPrice = await savePakistan.getVariantOptimismMintRate(Variant.RationBag);
+      expect(rationBagEtherPrice).to.be.eq(BigNumber.from("30000000000000000000"));
+    });
+
+    it("should return correct wei price for TemporaryShelter", async () => {
+      const rationBagEtherPrice = await savePakistan.getVariantOptimismMintRate(
+        Variant.TemporaryShelter
+      );
+      expect(rationBagEtherPrice).to.be.eq(BigNumber.from("100000000000000000000"));
+    });
+
+    it("should return correct wei price for HygieneKit", async () => {
+      const rationBagEtherPrice = await savePakistan.getVariantOptimismMintRate(Variant.HygieneKit);
+      expect(rationBagEtherPrice).to.be.eq(BigNumber.from("10000000000000000000"));
+    });
+
+    it("should return correct wei price for PortableToilets", async () => {
+      const rationBagEtherPrice = await savePakistan.getVariantOptimismMintRate(
+        Variant.PortableToilets
+      );
+      expect(rationBagEtherPrice).to.be.eq(BigNumber.from("65000000000000000000"));
+    });
+
+    it("should return correct wei price for Water", async () => {
+      const rationBagEtherPrice = await savePakistan.getVariantOptimismMintRate(Variant.Water);
+      expect(rationBagEtherPrice).to.be.eq(BigNumber.from("3000000000000000000"));
+    });
+
+    it("should return correct wei price for WaterWheel", async () => {
+      const rationBagEtherPrice = await savePakistan.getVariantOptimismMintRate(Variant.WaterWheel);
+      expect(rationBagEtherPrice).to.be.eq(BigNumber.from("25000000000000000000"));
     });
   });
 
@@ -230,7 +276,7 @@ describe("Spec: SavePakistan", () => {
       const contract = savePakistan.connect(user1);
 
       await expect(
-        contract.mintWithToken(Variant.HygieneKit, wethMock.address, "1")
+        contract.mintWithToken(Variant.HygieneKit, ethers.constants.AddressZero, "1")
       ).to.be.revertedWith("SavePakistan: This token is not supported.");
     });
 


### PR DESCRIPTION
- Adds Optimism Token address as https://optimistic.etherscan.io/token/0x4200000000000000000000000000000000000042

- Adds Optimism Token price feed for Chainlink on Optimism at https://optimistic.etherscan.io/address/0x0D276FC14719f9292D5C1eA2198673d1f4269246

- Adds optimismTokenAddr to supported tokens mapping

- Removes unused vars

- Adds MIT License to package.json

- Adds `getVariantOptimismMintRate`

- Adds OP Token to withdraw method

- Adds tests for the above